### PR TITLE
bugfix: parse flags before using them (notably: cfg.path)

### DIFF
--- a/main.go
+++ b/main.go
@@ -436,7 +436,7 @@ var metricFlowLatency = prometheus.NewGaugeVec(
 var metricBadPackets = prometheus.NewGaugeVec(
 	prometheus.GaugeOpts{
 		Name: "xping_bad_packets",
-		Help: "invalid ixp-xping packets received",
+		Help: "aaa",
 	},
 	[]string{"reason"},
 )

--- a/main.go
+++ b/main.go
@@ -412,7 +412,7 @@ func init() {
 var metricTotalLoss = prometheus.NewGaugeVec(
 	prometheus.GaugeOpts{
 		Name: "xping_peer_loss_total",
-		Help: "sliding window packetloss on {local,peer} L3 pair",
+		Help: "aaa",
 	},
 	[]string{"local", "peer"},
 )
@@ -420,7 +420,7 @@ var metricTotalLoss = prometheus.NewGaugeVec(
 var metricFlowLoss = prometheus.NewGaugeVec(
 	prometheus.GaugeOpts{
 		Name: "xping_peer_loss_per_flow",
-		Help: "sliding window packetloss on {local,peer,peerport} L4 flow",
+		Help: "aaa",
 	},
 	[]string{"local", "peer", "port"},
 )
@@ -428,7 +428,7 @@ var metricFlowLoss = prometheus.NewGaugeVec(
 var metricFlowLatency = prometheus.NewGaugeVec(
 	prometheus.GaugeOpts{
 		Name: "xping_peer_latency_per_flow",
-		Help: "sliding window round-trip latency on {local,peer,peerport} L4 flow, in usec",
+		Help: "aaa",
 	},
 	[]string{"local", "peer", "port"},
 )


### PR DESCRIPTION
The program defined a flag and used it before calling flag.Parse(), rendering the flag unusable.
I've moved the one `cfg.path` flag to its siblings in main(). I've initialized and parsed them before using them.
 
While I'm here, I've added descriptions to the Prometheus metrics, to better clarify that they are running averages latency in microseconds, and packet loss per L3 pair, and per individual L4 flow.